### PR TITLE
fix bug for search to remove "\\^

### DIFF
--- a/mkdocs/search.py
+++ b/mkdocs/search.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from mkdocs.compat import HTMLParser, unicode
 import json
-
+import re
 
 class SearchIndex(object):
     """
@@ -55,6 +55,9 @@ class SearchIndex(object):
         abs_url = page.abs_url
 
         # Create an entry for the full page.
+        content = re.sub('"',' ',content'"')
+        content = re.sub("\\\\",' ',content")
+        content = re.sub('\^',' ',content)
         self._add_entry(
             title=page.title,
             text=self.strip_tags(content).rstrip('\n'),


### PR DESCRIPTION
from tipesarch doc:
http://www.tipue.com/search/docs/#start
If you're not familiar with JSON, note that the last record doesn't end with a comma. Some characters may need to be escaped, such as " or . These should be preceded with a backslash. Tipue Search also uses ^ as a control character.